### PR TITLE
Detect when XNA is not installed and print a suitable error message before rethrowing

### DIFF
--- a/DLCQuestipelago/Plugin.cs
+++ b/DLCQuestipelago/Plugin.cs
@@ -44,8 +44,17 @@ namespace DLCQuestipelago
             Log.LogInfo($"Loading {PluginInfo.PLUGIN_NAME}...");
             Instance = this;
 
-            _harmony = new Harmony(PluginInfo.PLUGIN_NAME);
-            _harmony.PatchAll();
+            try
+            {
+                _harmony = new Harmony(PluginInfo.PLUGIN_NAME);
+                _harmony.PatchAll();
+            }
+            catch (FileNotFoundException fnfe)
+            {
+                if (fnfe.FileName.Contains("Microsoft.Xna.Framework"))
+                    Log.LogError($"Cannot load {PluginInfo.PLUGIN_NAME}: Microsoft XNA Framework 4.0 is not installed. Please run DLC Quest from Steam, then try again.");
+                throw;
+            }
 
             TaskExtensions.Initialize(Log);
             _archipelago = new ArchipelagoClient(Log, _harmony, OnItemReceived);


### PR DESCRIPTION
In the case of attempting to launch DLC Quest with the mod active without XNA installed, an extra message is logged stating the following:
> Microsoft XNA Framework 4.0 is not installed. Please run DLC Quest from Steam, then try again.

The hope is that users will see this message and try this fix before coming to the Discord looking for assistance, which will save everyone time 🙂